### PR TITLE
feat: add filter custom placeholder and dynamic icon visibility

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,7 @@ class MyApp extends StatelessWidget {
           showActions: true,
           showCheckBox: true,
           showFilter: true,
+          filterPlaceholder: "Custom placeholder",
           append: (parent) {
             print(parent.extra);
             return TreeNodeData(

--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -54,7 +54,7 @@ class TreeNode extends StatefulWidget {
 
 class _TreeNodeState extends State<TreeNode>
     with SingleTickerProviderStateMixin {
-  bool _isExpaned = false;
+  bool _isExpanded = false;
   bool _isChecked = false;
   bool _showLoading = false;
   Color _bgColor = Colors.transparent;
@@ -88,7 +88,7 @@ class _TreeNodeState extends State<TreeNode>
   @override
   initState() {
     super.initState();
-    _isExpaned = widget.data.expaned;
+    _isExpanded = widget.data.expaned;
     _isChecked = widget.data.checked;
     _rotationController = AnimationController(
       duration: const Duration(milliseconds: 300),
@@ -100,13 +100,15 @@ class _TreeNodeState extends State<TreeNode>
           widget.onCollapse(widget.data);
         }
       });
-    if (_isExpaned) {
+    if (_isExpanded) {
       _rotationController.forward();
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    bool hasData = widget.data.children.isNotEmpty || (widget.lazy && !_isExpanded);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -130,8 +132,8 @@ class _TreeNodeState extends State<TreeNode>
                 RotationTransition(
                   child: IconButton(
                     iconSize: 16,
-                    icon: widget.icon,
-                    onPressed: () {
+                    icon: hasData ? widget.icon : Container(),
+                    onPressed: hasData ? () {
                       widget.onTap(widget.data);
 
                       if (widget.lazy && widget.data.children.isEmpty) {
@@ -140,7 +142,7 @@ class _TreeNodeState extends State<TreeNode>
                         });
                         widget.load(widget.data).then((value) {
                           if (value) {
-                            _isExpaned = true;
+                            _isExpanded = true;
                             _rotationController.forward();
                             widget.onLoad(widget.data);
                           }
@@ -148,18 +150,18 @@ class _TreeNodeState extends State<TreeNode>
                           setState(() {});
                         });
                       } else {
-                        _isExpaned = !_isExpaned;
-                        if (_isExpaned) {
+                        _isExpanded = !_isExpanded;
+                        if (_isExpanded) {
                           _rotationController.forward();
                         } else {
                           _rotationController.reverse();
                         }
                         setState(() {});
                       }
-                    },
+                    } : null,
                   ),
                   turns: _turnsTween.animate(_rotationController),
-                ),
+                ),       
                 if (widget.showCheckBox)
                   Checkbox(
                     value: _isChecked,

--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -10,6 +10,7 @@ class TreeView extends StatefulWidget {
   final Widget icon;
   final double offsetLeft;
   final bool showFilter;
+  final String filterPlaceholder;
   final bool showActions;
   final bool showCheckBox;
 
@@ -39,6 +40,7 @@ class TreeView extends StatefulWidget {
     this.lazy = false,
     this.offsetLeft = 24.0,
     this.showFilter = false,
+    this.filterPlaceholder = 'Search',
     this.showActions = false,
     this.showCheckBox = false,
     this.icon = const Icon(Icons.expand_more, size: 16.0),
@@ -131,7 +133,12 @@ class _TreeViewState extends State<TreeView> {
                 right: 18.0,
                 bottom: 12.0,
               ),
-              child: TextField(onChanged: _onChange),
+              child: TextField(
+                onChanged: _onChange,
+                 decoration: InputDecoration(
+                  labelText: widget.filterPlaceholder,
+                )
+              ),
             ),
           ...List.generate(
             _renderList.length,


### PR DESCRIPTION
Hi!

I'm using this package for an application that i'm developing. I found it useful and I tried to improve it a little bit.

This PR contains:

1. A placeholder for the search filter. Now you can add a placeholder text by passing a custom string in the treeview constructor by the **filterPlaceholder** variable.
2. The Icon aside the data is dynamic. What it means is that before of this PR it appears also if the node doesn't contains children and also if the load function returns an empty list. Now you can see that if there is an empty node the icon will not appear and if the results of a load are none it disappears.
3. Change the _isExpaned to _isExpanded.

I hope this can be useful for someone :)
