### PR TITLE
Make content tappable, add the extra field to filter results, update examples and tests with the latest API

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter_tree/flutter_tree.dart';
 
 import './tree_data.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
@@ -13,14 +13,14 @@ class MyApp extends StatelessWidget {
     final data = [
       TreeNodeData(
         title: 'Load node 1',
-        expaned: false,
+        expanded: false,
         checked: true,
         children: [],
         extra: null,
       ),
       TreeNodeData(
         title: 'Load node 2',
-        expaned: false,
+        expanded: true,
         checked: false,
         children: [],
         extra: null,
@@ -48,7 +48,7 @@ class MyApp extends StatelessWidget {
             print(parent.extra);
             return TreeNodeData(
               title: 'Appended',
-              expaned: true,
+              expanded: true,
               checked: true,
               children: [],
             );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,7 @@ class MyApp extends StatelessWidget {
           showActions: true,
           showCheckBox: true,
           showFilter: true,
+          contentTappable: true,
           filterPlaceholder: "Custom placeholder",
           append: (parent) {
             print(parent.extra);

--- a/example/lib/tree_data.dart
+++ b/example/lib/tree_data.dart
@@ -42,7 +42,7 @@ TreeNodeData mapServerDataToTreeData(Map data) {
   return TreeNodeData(
     extra: data,
     title: data['text'],
-    expaned: data['show'],
+    expanded: data['show'],
     checked: data['checked'],
     children:
         List.from(data['children'].map((x) => mapServerDataToTreeData(x))),

--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -114,6 +114,9 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         InkWell(
+          splashColor: widget.contentTappable ? null : Colors.transparent,
+          highlightColor: widget.contentTappable ? null : Colors.transparent,
+          mouseCursor: widget.contentTappable ? SystemMouseCursors.click : MouseCursor.defer,
           onTap: widget.contentTappable ? () {
             if (hasData) {
               widget.onTap(widget.data);
@@ -123,7 +126,7 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
               widget.onCheck(_isChecked, widget.data);
               setState(() {});
             }
-          } : null,
+          } : (){},
           child: Container(
             margin: const EdgeInsets.only(bottom: 2.0),
             padding: const EdgeInsets.only(right: 12.0),

--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -58,7 +58,6 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
   bool _isExpanded = false;
   bool _isChecked = false;
   bool _showLoading = false;
-  Color _bgColor = Colors.transparent;
   late AnimationController _rotationController;
   final Tween<double> _turnsTween = Tween<double>(begin: -0.25, end: 0.0);
 
@@ -114,92 +113,79 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        MouseRegion(
-            onHover: (event) {},
-            onEnter: (event) {
-              _bgColor = Colors.grey[200]!;
+        InkWell(
+          onTap: widget.contentTappable ? () {
+            if (hasData) {
+              widget.onTap(widget.data);
+              toggleExpansion();
+            } else {
+              _isChecked = !_isChecked;
+              widget.onCheck(_isChecked, widget.data);
               setState(() {});
-            },
-            onExit: (event) {
-              _bgColor = Colors.transparent;
-              setState(() {});
-            },
-            cursor: widget.contentTappable ? SystemMouseCursors.click : MouseCursor.defer,
-            child: GestureDetector(
-              behavior: widget.contentTappable ? HitTestBehavior.deferToChild : HitTestBehavior.opaque,
-              onTap: widget.contentTappable ? () {
-                if (hasData) {
-                  widget.onTap(widget.data);
-                  toggleExpansion();
-                } else {
-                  _isChecked = !_isChecked;
-                  widget.onCheck(_isChecked, widget.data);
-                  setState(() {});
-                }
-              } : null,
-              child: Container(
-                color: _bgColor,
-                margin: const EdgeInsets.only(bottom: 2.0),
-                padding: const EdgeInsets.only(right: 12.0),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    RotationTransition(
-                      child: IconButton(
-                        iconSize: 16,
-                        icon: hasData ? widget.icon : Container(),
-                        onPressed: hasData ? () {
-                          widget.onTap(widget.data);
-                          toggleExpansion();
-                        } : null,
-                      ),
-                      turns: _turnsTween.animate(_rotationController),
-                    ),
-                    if (widget.showCheckBox)
-                      Checkbox(
-                        value: _isChecked,
-                        onChanged: (bool? value) {
-                          _isChecked = value!;
-                          widget.onCheck(_isChecked, widget.data);
-                          setState(() {});
-                        },
-                      ),
-                    if (widget.lazy && _showLoading)
-                      const SizedBox(
-                        width: 12.0,
-                        height: 12.0,
-                        child: CircularProgressIndicator(strokeWidth: 1.0),
-                      ),
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 6.0),
-                        child: Text(
-                          widget.data.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ),
-                    if (widget.showActions)
-                      TextButton(
-                        onPressed: () {
-                          widget.append(widget.data);
-                          widget.onAppend(widget.data, widget.parent);
-                        },
-                        child: const Text('Add', style: TextStyle(fontSize: 12.0)),
-                      ),
-                    if (widget.showActions)
-                      TextButton(
-                        onPressed: () {
-                          widget.remove(widget.data);
-                          widget.onRemove(widget.data, widget.parent);
-                        },
-                        child: const Text('Remove', style: TextStyle(fontSize: 12.0)),
-                      ),
-                  ],
+            }
+          } : null,
+          child: Container(
+            margin: const EdgeInsets.only(bottom: 2.0),
+            padding: const EdgeInsets.only(right: 12.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                RotationTransition(
+                  child: IconButton(
+                    iconSize: 16,
+                    icon: hasData ? widget.icon : Container(),
+                    onPressed: hasData ? () {
+                      widget.onTap(widget.data);
+                      toggleExpansion();
+                    } : null,
+                  ),
+                  turns: _turnsTween.animate(_rotationController),
                 ),
-              ),
-            )),
+                if (widget.showCheckBox)
+                  Checkbox(
+                    value: _isChecked,
+                    onChanged: (bool? value) {
+                      _isChecked = value!;
+                      widget.onCheck(_isChecked, widget.data);
+                      setState(() {});
+                    },
+                  ),
+                if (widget.lazy && _showLoading)
+                  const SizedBox(
+                    width: 12.0,
+                    height: 12.0,
+                    child: CircularProgressIndicator(strokeWidth: 1.0),
+                  ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                    child: Text(
+                      widget.data.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+                if (widget.showActions)
+                  TextButton(
+                    onPressed: () {
+                      widget.append(widget.data);
+                      widget.onAppend(widget.data, widget.parent);
+                    },
+                    child: const Text('Add', style: TextStyle(fontSize: 12.0)),
+                  ),
+                if (widget.showActions)
+                  TextButton(
+                    onPressed: () {
+                      widget.remove(widget.data);
+                      widget.onRemove(widget.data, widget.parent);
+                    },
+                    child: const Text('Remove', style: TextStyle(fontSize: 12.0)),
+                  ),
+              ],
+            ),
+          ),
+        ),
         SizeTransition(
           sizeFactor: _rotationController,
           child: Padding(

--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -10,6 +10,7 @@ class TreeNode extends StatefulWidget {
   final Widget icon;
   final bool showCheckBox;
   final bool showActions;
+  final bool contentTappable;
   final double offsetLeft;
 
   final Function(TreeNodeData node) onTap;
@@ -34,6 +35,7 @@ class TreeNode extends StatefulWidget {
     required this.offsetLeft,
     required this.showCheckBox,
     required this.showActions,
+    required this.contentTappable,
     required this.icon,
     required this.lazy,
     required this.load,
@@ -52,8 +54,7 @@ class TreeNode extends StatefulWidget {
   _TreeNodeState createState() => _TreeNodeState();
 }
 
-class _TreeNodeState extends State<TreeNode>
-    with SingleTickerProviderStateMixin {
+class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin {
   bool _isExpanded = false;
   bool _isChecked = false;
   bool _showLoading = false;
@@ -74,6 +75,7 @@ class _TreeNodeState extends State<TreeNode>
         offsetLeft: widget.offsetLeft,
         showCheckBox: widget.showCheckBox,
         showActions: widget.showActions,
+        contentTappable: widget.contentTappable,
         onTap: widget.onTap,
         onCheck: widget.onCheck,
         onExpand: widget.onExpand,
@@ -113,101 +115,91 @@ class _TreeNodeState extends State<TreeNode>
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         MouseRegion(
-          onHover: (event) {},
-          onEnter: (event) {
-            _bgColor = Colors.grey[200]!;
-            setState(() {});
-          },
-          onExit: (event) {
-            _bgColor = Colors.transparent;
-            setState(() {});
-          },
-          child: Container(
-            color: _bgColor,
-            margin: const EdgeInsets.only(bottom: 2.0),
-            padding: const EdgeInsets.only(right: 12.0),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                RotationTransition(
-                  child: IconButton(
-                    iconSize: 16,
-                    icon: hasData ? widget.icon : Container(),
-                    onPressed: hasData ? () {
-                      widget.onTap(widget.data);
-
-                      if (widget.lazy && widget.data.children.isEmpty) {
-                        setState(() {
-                          _showLoading = true;
-                        });
-                        widget.load(widget.data).then((value) {
-                          if (value) {
-                            _isExpanded = true;
-                            _rotationController.forward();
-                            widget.onLoad(widget.data);
-                          }
-                          _showLoading = false;
-                          setState(() {});
-                        });
-                      } else {
-                        _isExpanded = !_isExpanded;
-                        if (_isExpanded) {
-                          _rotationController.forward();
-                        } else {
-                          _rotationController.reverse();
-                        }
-                        setState(() {});
-                      }
-                    } : null,
-                  ),
-                  turns: _turnsTween.animate(_rotationController),
-                ),       
-                if (widget.showCheckBox)
-                  Checkbox(
-                    value: _isChecked,
-                    onChanged: (bool? value) {
-                      _isChecked = value!;
-                      widget.onCheck(_isChecked, widget.data);
-                      setState(() {});
-                    },
-                  ),
-                if (widget.lazy && _showLoading)
-                  const SizedBox(
-                    width: 12.0,
-                    height: 12.0,
-                    child: CircularProgressIndicator(strokeWidth: 1.0),
-                  ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 6.0),
-                    child: Text(
-                      widget.data.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+            onHover: (event) {},
+            onEnter: (event) {
+              _bgColor = Colors.grey[200]!;
+              setState(() {});
+            },
+            onExit: (event) {
+              _bgColor = Colors.transparent;
+              setState(() {});
+            },
+            cursor: widget.contentTappable ? SystemMouseCursors.click : MouseCursor.defer,
+            child: GestureDetector(
+              behavior: widget.contentTappable ? HitTestBehavior.deferToChild : HitTestBehavior.opaque,
+              onTap: widget.contentTappable ? () {
+                if (hasData) {
+                  widget.onTap(widget.data);
+                  toggleExpansion();
+                } else {
+                  _isChecked = !_isChecked;
+                  widget.onCheck(_isChecked, widget.data);
+                  setState(() {});
+                }
+              } : null,
+              child: Container(
+                color: _bgColor,
+                margin: const EdgeInsets.only(bottom: 2.0),
+                padding: const EdgeInsets.only(right: 12.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    RotationTransition(
+                      child: IconButton(
+                        iconSize: 16,
+                        icon: hasData ? widget.icon : Container(),
+                        onPressed: hasData ? () {
+                          widget.onTap(widget.data);
+                          toggleExpansion();
+                        } : null,
+                      ),
+                      turns: _turnsTween.animate(_rotationController),
                     ),
-                  ),
+                    if (widget.showCheckBox)
+                      Checkbox(
+                        value: _isChecked,
+                        onChanged: (bool? value) {
+                          _isChecked = value!;
+                          widget.onCheck(_isChecked, widget.data);
+                          setState(() {});
+                        },
+                      ),
+                    if (widget.lazy && _showLoading)
+                      const SizedBox(
+                        width: 12.0,
+                        height: 12.0,
+                        child: CircularProgressIndicator(strokeWidth: 1.0),
+                      ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                        child: Text(
+                          widget.data.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                    if (widget.showActions)
+                      TextButton(
+                        onPressed: () {
+                          widget.append(widget.data);
+                          widget.onAppend(widget.data, widget.parent);
+                        },
+                        child: const Text('Add', style: TextStyle(fontSize: 12.0)),
+                      ),
+                    if (widget.showActions)
+                      TextButton(
+                        onPressed: () {
+                          widget.remove(widget.data);
+                          widget.onRemove(widget.data, widget.parent);
+                        },
+                        child: const Text('Remove', style: TextStyle(fontSize: 12.0)),
+                      ),
+                  ],
                 ),
-                if (widget.showActions)
-                  TextButton(
-                    onPressed: () {
-                      widget.append(widget.data);
-                      widget.onAppend(widget.data, widget.parent);
-                    },
-                    child: const Text('Add', style: TextStyle(fontSize: 12.0)),
-                  ),
-                if (widget.showActions)
-                  TextButton(
-                    onPressed: () {
-                      widget.remove(widget.data);
-                      widget.onRemove(widget.data, widget.parent);
-                    },
-                    child:
-                        const Text('Remove', style: TextStyle(fontSize: 12.0)),
-                  ),
-              ],
-            ),
-          ),
-        ),
+              ),
+            )),
         SizeTransition(
           sizeFactor: _rotationController,
           child: Padding(
@@ -217,5 +209,30 @@ class _TreeNodeState extends State<TreeNode>
         )
       ],
     );
+  }
+
+  void toggleExpansion() {
+    if (widget.lazy && widget.data.children.isEmpty) {
+      setState(() {
+        _showLoading = true;
+      });
+      widget.load(widget.data).then((value) {
+        if (value) {
+          _isExpanded = true;
+          _rotationController.forward();
+          widget.onLoad(widget.data);
+        }
+        _showLoading = false;
+        setState(() {});
+      });
+    } else {
+      _isExpanded = !_isExpanded;
+      if (_isExpanded) {
+        _rotationController.forward();
+      } else {
+        _rotationController.reverse();
+      }
+      setState(() {});
+    }
   }
 }

--- a/lib/src/tree_node_data.dart
+++ b/lib/src/tree_node_data.dart
@@ -12,4 +12,7 @@ class TreeNodeData {
     required this.children,
     this.extra,
   });
+
+  TreeNodeData.from(TreeNodeData other):
+    this(title: other.title, expanded: other.expanded, checked: other.checked, extra: other.extra, children: other.children);
 }

--- a/lib/src/tree_node_data.dart
+++ b/lib/src/tree_node_data.dart
@@ -15,4 +15,9 @@ class TreeNodeData {
 
   TreeNodeData.from(TreeNodeData other):
     this(title: other.title, expanded: other.expanded, checked: other.checked, extra: other.extra, children: other.children);
+
+  @override
+  String toString() {
+    return 'TreeNodeData{title: $title, expanded: $expanded, checked: $checked, extra: $extra, ${children.length} children}';
+  }
 }

--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -13,6 +13,7 @@ class TreeView extends StatefulWidget {
   final String filterPlaceholder;
   final bool showActions;
   final bool showCheckBox;
+  final bool contentTappable;
   final Function(TreeNodeData node)? onTap;
   final void Function(TreeNodeData node)? onLoad;
   final void Function(TreeNodeData node)? onExpand;
@@ -42,6 +43,7 @@ class TreeView extends StatefulWidget {
     this.filterPlaceholder = 'Search',
     this.showActions = false,
     this.showCheckBox = false,
+    this.contentTappable = false,
     this.icon = const Icon(Icons.expand_more, size: 16.0),
   }) : super(key: key);
 
@@ -159,6 +161,7 @@ class _TreeViewState extends State<TreeView> {
                 offsetLeft: widget.offsetLeft,
                 showCheckBox: widget.showCheckBox,
                 showActions: widget.showActions,
+                contentTappable: widget.contentTappable,
                 onTap: widget.onTap ?? (n) {},
                 onLoad: widget.onLoad ?? (n) {},
                 onCheck: widget.onCheck ?? (b, n) {},

--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -57,18 +57,13 @@ class _TreeViewState extends State<TreeView> {
     List<TreeNodeData> tempNodes = [];
 
     for (int i = 0; i < list.length; i++) {
-      TreeNodeData tempNode = TreeNodeData(
-        title: list[i].title,
-        checked: list[i].checked,
-        expanded: list[i].expanded,
-        children: list[i].children,
-      );
+      TreeNodeData tempNode = TreeNodeData.from(list[i]);
 
       if (tempNode.children.isNotEmpty) {
         tempNode.children = _filter(val, tempNode.children);
       }
 
-      if (tempNode.title.contains(new RegExp(val, caseSensitive: false)) || tempNode.children.isNotEmpty) {
+      if (tempNode.title.contains(RegExp(val, caseSensitive: false)) || tempNode.children.isNotEmpty) {
         tempNodes.add(tempNode);
       }
     }

--- a/test/tree_view_test.dart
+++ b/test/tree_view_test.dart
@@ -11,7 +11,7 @@ MaterialApp myApp = MaterialApp(
       data: [
         TreeNodeData(
           title: 'title',
-          expaned: false,
+          expanded: false,
           checked: false,
           children: [],
           extra: null,


### PR DESCRIPTION
I made some changes that makes this more usable for me:
- Add an option `contentTappable` to `TreeView` that makes the content tappable, which will expand/collapse or select/unselect the node depending on if the node has children (following changes in #12)
- Add field `extra` to the filter result nodes
- Update examples and tests with the latest API (changed `expaned` to `expanded`)