### PR TITLE
Add option to manage parent state

### DIFF
--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -5,6 +5,7 @@ import '../flutter_tree.dart';
 class TreeNode extends StatefulWidget {
   final TreeNodeData data;
   final TreeNodeData parent;
+  final State? parentState;
 
   final bool lazy;
   final Widget icon;
@@ -32,6 +33,7 @@ class TreeNode extends StatefulWidget {
     Key? key,
     required this.data,
     required this.parent,
+    this.parentState,
     required this.offsetLeft,
     required this.showCheckBox,
     required this.showActions,
@@ -66,6 +68,7 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
       return TreeNode(
         data: list[index],
         parent: widget.data,
+        parentState: widget.parentState != null ? this : null,
         remove: widget.remove,
         append: widget.append,
         icon: widget.icon,
@@ -108,6 +111,8 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
 
   @override
   Widget build(BuildContext context) {
+    if (widget.parentState != null) _isChecked = widget.data.checked;
+
     bool hasData = widget.data.children.isNotEmpty || (widget.lazy && !_isExpanded);
 
     return Column(
@@ -150,6 +155,7 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
                     onChanged: (bool? value) {
                       _isChecked = value!;
                       widget.onCheck(_isChecked, widget.data);
+                      if (widget.parentState != null) _checkUncheckParent();
                       setState(() {});
                     },
                   ),
@@ -223,5 +229,16 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
       }
       setState(() {});
     }
+  }
+
+  void _checkUncheckParent() {
+    // Check/uncheck all children based on parent state
+    widget.data.checked = _isChecked;
+    widget.data.children.forEach((child) => child.checked = _isChecked);
+    widget.parentState!.setState(() {});
+
+    // Check/uncheck parent based on children state
+    widget.parent.checked = widget.parent.children.every((e) => e.checked);
+    widget.parentState!.setState(() {});
   }
 }

--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -154,8 +154,8 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
                     value: _isChecked,
                     onChanged: (bool? value) {
                       _isChecked = value!;
-                      widget.onCheck(_isChecked, widget.data);
                       if (widget.parentState != null) _checkUncheckParent();
+                      widget.onCheck(_isChecked, widget.data);
                       setState(() {});
                     },
                   ),

--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -14,6 +14,12 @@ class TreeView extends StatefulWidget {
   final bool showActions;
   final bool showCheckBox;
   final bool contentTappable;
+
+  /// Desired behavior:
+  /// - if I check/uncheck a parent I want all children to be checked/unchecked
+  /// - if I check/uncheck all children I want the parent to be checked/unchecked
+  final bool manageParentState;
+
   final Function(TreeNodeData node)? onTap;
   final void Function(TreeNodeData node)? onLoad;
   final void Function(TreeNodeData node)? onExpand;
@@ -45,6 +51,7 @@ class TreeView extends StatefulWidget {
     this.showCheckBox = false,
     this.contentTappable = false,
     this.icon = const Icon(Icons.expand_more, size: 16.0),
+    this.manageParentState = false,
   }) : super(key: key);
 
   @override
@@ -155,6 +162,7 @@ class _TreeViewState extends State<TreeView> {
                 remove: remove,
                 append: append,
                 parent: _root,
+                parentState: widget.manageParentState ? this : null,
                 data: _renderList[index],
                 icon: widget.icon,
                 lazy: widget.lazy,


### PR DESCRIPTION
Desired behavior:
- if I check/uncheck a parent I want all children to be checked/unchecked
- if I check/uncheck all children I want the parent to be checked/unchecked

I added an option to implement the behavior above:

```dart
            TreeView(
              data: _treeData,
              manageParentState: true,
            ),
```

So, for example:
```
Parent
- Child 1
- Child 2
```

If I check both "Child 1" and "Child 2", "Parent" is checked, otherwise "Parent" is unchecked.
If I check "Parent", both "Child 1" and "Child 2" are checked.
If I uncheck "Parent", both "Child 1" and "Child 2" are unchecked.
