### PR TITLE
Add checkColor and fillColor to data to be used in checkboxes

### DIFF
--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -147,6 +147,8 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
                 if (widget.showCheckBox)
                   Checkbox(
                     value: _isChecked,
+                    checkColor: widget.data.checkBoxCheckColor,
+                    fillColor: widget.data.checkBoxFillColor,
                     onChanged: (bool? value) {
                       _isChecked = value!;
                       widget.onCheck(_isChecked, widget.data);

--- a/lib/src/tree_node_data.dart
+++ b/lib/src/tree_node_data.dart
@@ -1,8 +1,12 @@
+import 'package:flutter/material.dart';
+
 class TreeNodeData {
   String title;
   bool expanded;
   bool checked;
   dynamic extra;
+  final Color? checkBoxCheckColor;
+  final MaterialStateProperty<Color>? checkBoxFillColor;
   List<TreeNodeData> children;
 
   TreeNodeData({
@@ -11,6 +15,8 @@ class TreeNodeData {
     required this.checked,
     required this.children,
     this.extra,
+    this.checkBoxCheckColor,
+    this.checkBoxFillColor,
   });
 
   TreeNodeData.from(TreeNodeData other):


### PR DESCRIPTION
Allow consumers to specify checkbox colors:

```dart
TreeNodeData(
              title: "Black and white checkbox",
              checked: true,
              checkBoxCheckColor: Colors.black,
              checkBoxFillColor: MaterialStateProperty.all(Colors.white),
              children: [],
);
```