### PR TITLE
Add background color getter to NodeTreeData

### DIFF
--- a/lib/src/tree_node.dart
+++ b/lib/src/tree_node.dart
@@ -171,12 +171,16 @@ class _TreeNodeState extends State<TreeNode> with SingleTickerProviderStateMixin
                     child: CircularProgressIndicator(strokeWidth: 1.0),
                   ),
                 Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 6.0),
-                    child: Text(
-                      widget.data.title,
-                      maxLines: widget.maxLines ?? 1,
-                      overflow: TextOverflow.ellipsis,
+                  child: Container(
+                    key: ValueKey(widget.data.backgroundColor?.call()),
+                    color: widget.data.backgroundColor?.call(),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                      child: Text(
+                        widget.data.title,
+                        maxLines: widget.maxLines ?? 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/tree_node_data.dart
+++ b/lib/src/tree_node_data.dart
@@ -7,6 +7,7 @@ class TreeNodeData {
   dynamic extra;
   final Color? checkBoxCheckColor;
   final MaterialStateProperty<Color>? checkBoxFillColor;
+  final ValueGetter<Color>? backgroundColor;
   List<TreeNodeData> children;
 
   TreeNodeData({
@@ -17,6 +18,7 @@ class TreeNodeData {
     this.extra,
     this.checkBoxCheckColor,
     this.checkBoxFillColor,
+    this.backgroundColor,
   });
 
   TreeNodeData.from(TreeNodeData other):


### PR DESCRIPTION
Allows to dynamically highlight a row like this:

![EasyHour](https://user-images.githubusercontent.com/4000539/204088937-e741e1d0-0446-4907-a95a-590d808cfc0c.gif)
